### PR TITLE
Note volume timing fix

### DIFF
--- a/src/SynthInstrument.js
+++ b/src/SynthInstrument.js
@@ -76,7 +76,7 @@ class SynthInstrument { // eslint-disable-line no-unused-vars
       const volume = ((this.gridHeight - this.polyphony[gridX]) / this.gridHeight)
         * (highVolume - lowVolume) + lowVolume;
       try {
-        this.players[this.currentPlayer].volume.value = volume;
+        this.players[this.currentPlayer].volume.setValueAtTime(volume, time);
         this.players[this.currentPlayer].start(
           time, gridY * this.noteOffset, this.noteOffset,
         );

--- a/src/ToneMatrix.js
+++ b/src/ToneMatrix.js
@@ -149,8 +149,6 @@ class ToneMatrix { // eslint-disable-line no-unused-vars
       }
     });
 
-    this.SYNTHLATENCY = 0.25; // Queue events ahead of time
-    Tone.context.latencyHint = this.SYNTHLATENCY;
     Tone.Transport.loopEnd = '1m'; // loop at one measure
     Tone.Transport.loop = true;
     Tone.Transport.start();


### PR DESCRIPTION
Removed latency scheduling workaround and instead scheduled volume changes at the correct time when scheduling note playing.

My guess is that the latencyhint was a hack for some volume timing issues, since I got distortion/clipping when I removed it. In the latest version of tone.js however, latencyhint is read only / getter, and this hack no longer works.

Changing the scheduler to set the volume at the correct time seems to solve the issue, and works with the latest version of Tone.js